### PR TITLE
Switch SpotlightActionConfig to use inline callbacks

### DIFF
--- a/lib/src/configs/spotlight_action_config.dart
+++ b/lib/src/configs/spotlight_action_config.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:spotlight_ant/spotlight_ant.dart';
 import 'package:spotlight_ant/src/spotlight_ant.dart';
 
 class SpotlightActionConfig {
@@ -28,13 +29,13 @@ class SpotlightActionConfig {
   /// Default using:
   /// ```dart
   /// IconButton(
-  ///   onPressed: () => prev(),
+  ///   onPressed: () => next(),
   ///   tooltip: 'Next spotlight',
   ///   color: Colors.white,
   ///   icon: const Icon(Icons.arrow_forward_ios_sharp),
   /// );
   /// ```
-  final Widget? next;
+  final Widget Function(VoidCallback callback)? next;
 
   /// Pressed the action widget will go to previous spotlight.
   ///
@@ -47,7 +48,7 @@ class SpotlightActionConfig {
   ///   icon: const Icon(Icons.arrow_back_ios_sharp),
   /// );
   /// ```
-  final Widget? prev;
+  final Widget Function(VoidCallback callback)? prev;
 
   /// Pressed the action widget will skip all spotlights.
   ///
@@ -60,7 +61,7 @@ class SpotlightActionConfig {
   ///   icon: const Icon(Icons.close_sharp),
   /// );
   /// ```
-  final Widget? skip;
+  final Widget Function(VoidCallback callback)? skip;
 
   const SpotlightActionConfig({
     this.enabled = const [SpotlightAntAction.skip],

--- a/lib/src/spotlight_gaffer.dart
+++ b/lib/src/spotlight_gaffer.dart
@@ -176,31 +176,34 @@ class SpotlightGafferState extends State<SpotlightGaffer> with TickerProviderSta
     for (final action in currentAnt!.widget.action.enabled) {
       switch (action) {
         case SpotlightAntAction.prev:
-          yield currentAnt!.widget.action.prev ??
-              IconButton(
-                onPressed: () => prev(),
-                tooltip: 'Previous spotlight',
-                color: Colors.white,
-                icon: const Icon(Icons.arrow_back_ios_sharp),
-              );
+          yield currentAnt!.widget.action.prev != null
+              ? currentAnt!.widget.action.prev!(prev)
+              : IconButton(
+                  onPressed: () => prev(),
+                  tooltip: 'Previous spotlight',
+                  color: Colors.white,
+                  icon: const Icon(Icons.arrow_back_ios_sharp),
+                );
           break;
         case SpotlightAntAction.next:
-          yield currentAnt!.widget.action.next ??
-              IconButton(
-                onPressed: () => next(),
-                tooltip: 'Next spotlight',
-                color: Colors.white,
-                icon: const Icon(Icons.arrow_forward_ios_sharp),
-              );
+          yield currentAnt!.widget.action.next != null
+              ? currentAnt!.widget.action.next!(next)
+              : IconButton(
+                  onPressed: () => next(),
+                  tooltip: 'Next spotlight',
+                  color: Colors.white,
+                  icon: const Icon(Icons.arrow_forward_ios_sharp),
+                );
           break;
         case SpotlightAntAction.skip:
-          yield currentAnt!.widget.action.skip ??
-              IconButton(
-                onPressed: () => skip(),
-                tooltip: 'Skip spotlight show',
-                color: Colors.white,
-                icon: const Icon(Icons.close_sharp),
-              );
+          yield currentAnt!.widget.action.skip != null
+              ? currentAnt!.widget.action.skip!(skip)
+              : IconButton(
+                  onPressed: () => skip(),
+                  tooltip: 'Skip spotlight show',
+                  color: Colors.white,
+                  icon: const Icon(Icons.close_sharp),
+                );
           break;
       }
     }

--- a/lib/src/spotlight_gaffer.dart
+++ b/lib/src/spotlight_gaffer.dart
@@ -176,34 +176,31 @@ class SpotlightGafferState extends State<SpotlightGaffer> with TickerProviderSta
     for (final action in currentAnt!.widget.action.enabled) {
       switch (action) {
         case SpotlightAntAction.prev:
-          yield currentAnt!.widget.action.prev != null
-              ? currentAnt!.widget.action.prev!(prev)
-              : IconButton(
-                  onPressed: () => prev(),
-                  tooltip: 'Previous spotlight',
-                  color: Colors.white,
-                  icon: const Icon(Icons.arrow_back_ios_sharp),
-                );
+          yield currentAnt!.widget.action.prev?.call(prev) ??
+              IconButton(
+                onPressed: prev,
+                tooltip: 'Previous spotlight',
+                color: Colors.white,
+                icon: const Icon(Icons.arrow_back_ios_sharp),
+              );
           break;
         case SpotlightAntAction.next:
-          yield currentAnt!.widget.action.next != null
-              ? currentAnt!.widget.action.next!(next)
-              : IconButton(
-                  onPressed: () => next(),
-                  tooltip: 'Next spotlight',
-                  color: Colors.white,
-                  icon: const Icon(Icons.arrow_forward_ios_sharp),
-                );
+          yield currentAnt!.widget.action.next?.call(next) ??
+              IconButton(
+                onPressed: next,
+                tooltip: 'Next spotlight',
+                color: Colors.white,
+                icon: const Icon(Icons.arrow_forward_ios_sharp),
+              );
           break;
         case SpotlightAntAction.skip:
-          yield currentAnt!.widget.action.skip != null
-              ? currentAnt!.widget.action.skip!(skip)
-              : IconButton(
-                  onPressed: () => skip(),
-                  tooltip: 'Skip spotlight show',
-                  color: Colors.white,
-                  icon: const Icon(Icons.close_sharp),
-                );
+          yield currentAnt!.widget.action.skip?.call(skip) ??
+              IconButton(
+                onPressed: skip,
+                tooltip: 'Skip spotlight show',
+                color: Colors.white,
+                icon: const Icon(Icons.close_sharp),
+              );
           break;
       }
     }

--- a/test/action_buttons_test.dart
+++ b/test/action_buttons_test.dart
@@ -18,9 +18,9 @@ void main() {
 
     testWidgets('basic', (WidgetTester tester) async {
       final show = GlobalKey<SpotlightShowState>();
-      final nextButton = ValueKey('next');
-      final prevButton = ValueKey('prev');
-      final skipButton = ValueKey('skip');
+      const nextButton = ValueKey('next');
+      const prevButton = ValueKey('prev');
+      const skipButton = ValueKey('skip');
 
       int onShown = 0;
       int onDismissed = 0;

--- a/test/action_buttons_test.dart
+++ b/test/action_buttons_test.dart
@@ -1,0 +1,111 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:spotlight_ant/spotlight_ant.dart';
+
+void main() {
+  group('Spotlight Ant and Custom Action button overrides', () {
+    const actions = [
+      SpotlightAntAction.prev,
+      SpotlightAntAction.skip,
+      SpotlightAntAction.next,
+    ];
+    const duration = SpotlightDurationConfig(
+      zoomIn: Duration(milliseconds: 5),
+      zoomOut: Duration(milliseconds: 5),
+      contentFadeIn: Duration.zero,
+      bump: Duration.zero,
+    );
+
+    testWidgets('basic', (WidgetTester tester) async {
+      final show = GlobalKey<SpotlightShowState>();
+      final nextButton = ValueKey('next');
+      final prevButton = ValueKey('prev');
+      final skipButton = ValueKey('skip');
+
+      int onShown = 0;
+      int onDismissed = 0;
+      int onSkip = 0;
+      int onFinish = 0;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: SpotlightShow(
+            key: show,
+            onSkip: () => onSkip++,
+            onFinish: () => onFinish++,
+            child: Column(
+              children: [
+                SpotlightAnt(
+                  duration: duration,
+                  content: const SpotlightContent(child: Text('content-1')),
+                  onShown: () => onShown++,
+                  onDismissed: () => onDismissed++,
+                  action: SpotlightActionConfig(
+                    enabled: actions,
+                    next: (callback) => ElevatedButton(
+                      key: nextButton,
+                      onPressed: () => callback(),
+                      child: const Text('Next'),
+                    ),
+                    skip: (callback) => ElevatedButton(
+                      key: skipButton,
+                      onPressed: () => callback(),
+                      child: const Text('Skip'),
+                    ),
+                  ),
+                  child: const Text('widget-1'),
+                ),
+                SpotlightAnt(
+                  duration: duration,
+                  content: const SpotlightContent(child: Text('content-2')),
+                  onShown: () => onShown++,
+                  onDismissed: () => onDismissed++,
+                  action: SpotlightActionConfig(
+                    enabled: actions,
+                    prev: (callback) => ElevatedButton(
+                      key: prevButton,
+                      onPressed: () => callback(),
+                      child: const Text('Prev'),
+                    ),
+                  ),
+                  child: const Text('widget-2'),
+                ),
+              ],
+            ),
+          ),
+        ),
+      );
+
+      await tester.pumpAndSettle();
+
+      await tester.pump(const Duration(milliseconds: 1));
+      expect(onShown, equals(0));
+      expect(find.text('content-1'), findsOneWidget);
+      await tester.pump(const Duration(milliseconds: 6));
+      expect(onShown, equals(1));
+
+      // forward
+      await tester.tap(find.byKey(nextButton));
+      await tester.pump(const Duration(milliseconds: 1));
+      await tester.pump(const Duration(milliseconds: 6));
+      expect(find.text('content-2'), findsOneWidget);
+      await tester.pump(const Duration(milliseconds: 6));
+      expect(onShown, equals(2));
+
+      // backward
+      await tester.tap(find.byKey(prevButton));
+      await tester.pump(const Duration(milliseconds: 1));
+      await tester.pump(const Duration(milliseconds: 6));
+      expect(find.text('content-1'), findsOneWidget);
+      await tester.pump(const Duration(milliseconds: 6));
+      expect(onShown, equals(3));
+
+      // skip
+      await tester.tap(find.byKey(skipButton));
+      await tester.pump(const Duration(milliseconds: 1));
+      await tester.pump(const Duration(milliseconds: 6));
+      expect(find.text('content-1'), findsNothing);
+      expect(find.text('content-2'), findsNothing);
+    });
+  });
+}


### PR DESCRIPTION
This removes the dependency on `SpotlightShow.of` for custom action implementations.
Because the backdrop (and the action buttons) are kept in an `Overlay`, access to `SpotlightShow.of` will always fail. 

As a remediation, the button builders are now dynamic and receive the necessary callback directly.