### PR TITLE
feat: add finish action and custom pop action

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,10 +101,13 @@ The configuration of `SpotlightShow`:
 
 | Name | Default | Desc. |
 | - | - | - |
-| showAfterInit | `true` | If you want to fire it by program, set it to false |
+| enable | `true` | Wheather enable the show |
+| startWhenReady | `true` | If you want to fire it by program, set it to false |
 | showWaitFuture | `null` | Pass the `Future` and it will wait until it done and start the show. |
 | onSkip | `null` | Callback after tapping `SpotlightAntAction.skip`. |
 | onFinish | `null` | Callback after finish the show. |
+| popAction | `SpotlightAntAction.skip` | Action after pressing pop button. |
+| readinessChecker | `null` | A function to check whether the show is ready to start. |
 
 Go to [API doc](https://pub.dev/documentation/spotlight_ant/latest/spotlight_ant/spotlight_ant-library.html) for details.
 

--- a/lib/src/configs/spotlight_action_config.dart
+++ b/lib/src/configs/spotlight_action_config.dart
@@ -73,6 +73,7 @@ class SpotlightActionConfig {
   ///   color: Colors.white,
   ///   icon: const Icon(Icons.check_sharp),
   /// );
+  /// ```
   final Widget Function(VoidCallback callback)? finish;
 
   const SpotlightActionConfig({

--- a/lib/src/configs/spotlight_action_config.dart
+++ b/lib/src/configs/spotlight_action_config.dart
@@ -63,11 +63,24 @@ class SpotlightActionConfig {
   /// ```
   final Widget Function(VoidCallback callback)? skip;
 
+  /// Pressed the action widget will finish the spotlight show.
+  ///
+  /// Default using:
+  /// ```dart
+  /// IconButton(
+  ///   onPressed: () => finish(),
+  ///   tooltip: 'Finish spotlight show',
+  ///   color: Colors.white,
+  ///   icon: const Icon(Icons.check_sharp),
+  /// );
+  final Widget Function(VoidCallback callback)? finish;
+
   const SpotlightActionConfig({
     this.enabled = const [SpotlightAntAction.skip],
     this.builder,
     this.next,
     this.prev,
     this.skip,
+    this.finish,
   });
 }

--- a/lib/src/spotlight_ant.dart
+++ b/lib/src/spotlight_ant.dart
@@ -211,4 +211,5 @@ enum SpotlightAntAction {
   prev,
   next,
   skip,
+  finish,
 }

--- a/lib/src/spotlight_gaffer.dart
+++ b/lib/src/spotlight_gaffer.dart
@@ -202,6 +202,15 @@ class SpotlightGafferState extends State<SpotlightGaffer> with TickerProviderSta
                 icon: const Icon(Icons.close_sharp),
               );
           break;
+        case SpotlightAntAction.finish:
+          yield currentAnt!.widget.action.finish?.call(finish) ??
+              IconButton(
+                onPressed: finish,
+                tooltip: 'Finish spotlight show',
+                color: Colors.white,
+                icon: const Icon(Icons.check_sharp),
+              );
+          break;
       }
     }
   }

--- a/lib/src/spotlight_show.dart
+++ b/lib/src/spotlight_show.dart
@@ -160,12 +160,15 @@ class SpotlightShowState extends State<SpotlightShow> {
 
   @override
   Widget build(BuildContext context) {
-    return PopScope(
-      canPop: widget.popAction == null || !isPerforming,
-      onPopInvoked: (popped) {
-        if (!popped) {
+    // ignore: deprecated_member_use
+    return WillPopScope(
+      onWillPop: () async {
+        final canPop = widget.popAction == null || !isPerforming;
+        if (!canPop) {
           perform(widget.popAction!);
         }
+
+        return canPop;
       },
       child: _ShowScope(
         showState: this,

--- a/test/basic_test.dart
+++ b/test/basic_test.dart
@@ -227,7 +227,7 @@ void main() {
       await tester.pump(const Duration(milliseconds: 1)); // zoom in
       expect(onShow, equals(1));
 
-      show.currentState?.next();
+      show.currentState?.perform(SpotlightAntAction.next);
       await tester.pump(const Duration(milliseconds: 1)); // zoom out and in
       expect(onDismiss, equals(1));
       expect(onShow, equals(3));
@@ -237,7 +237,7 @@ void main() {
       await tester.pump(const Duration(milliseconds: 1));
       expect(onDismiss, equals(1));
 
-      show.currentState?.prev();
+      show.currentState?.perform(SpotlightAntAction.prev);
       await tester.pump(const Duration(milliseconds: 1));
       expect(onDismiss, equals(3));
       expect(onShow, equals(4));
@@ -253,13 +253,13 @@ void main() {
       expect(onFinish, equals(0));
 
       // already finish should not fire again
-      show.currentState?.skip();
+      show.currentState?.perform(SpotlightAntAction.skip);
       await tester.pump(const Duration(milliseconds: 1));
       expect(onSkip, equals(1));
 
       show.currentState?.start();
       await tester.pump(const Duration(milliseconds: 1));
-      show.currentState?.finish();
+      show.currentState?.perform(SpotlightAntAction.finish);
       await tester.pump(const Duration(milliseconds: 1));
       expect(onFinish, equals(1));
       expect(onSkip, equals(1));
@@ -324,6 +324,7 @@ void main() {
       await tester.pumpWidget(MaterialApp(
         home: SpotlightShow(
           onSkip: () => skipped = true,
+          popAction: SpotlightAntAction.skip,
           child: const SpotlightAnt(
             content: Text('content'),
             duration: SpotlightDurationConfig.zero,


### PR DESCRIPTION
## Purpose

Allow user custom action after pressing pop button.

## Implement

Add one item `SpotlightAntAction.finish` and use default finish button as: 

```dart
IconButton(
  onPressed: () => finish(),
  tooltip: 'Finish spotlight show',
  color: Colors.white,
  icon: const Icon(Icons.check_sharp),
);
```